### PR TITLE
Fix SQL runner connection reset handling

### DIFF
--- a/db_handler.py
+++ b/db_handler.py
@@ -333,6 +333,15 @@ class DatabaseManager:
                 _ = cur.fetchone()
             finally:
                 cur.close()
+            try:
+                # End the implicit transaction opened by the ping so the
+                # server doesn't terminate the session for idling in a
+                # transaction block.
+                self.conn.rollback()
+            except Exception:
+                # Some drivers complain if there's nothing to roll back;
+                # we only care that the connection is left clean.
+                pass
         except Exception:
             self._reconnect()
 


### PR DESCRIPTION
## Summary
- end the keep-alive ping transaction so PostgreSQL does not terminate the session for idling
- guard SQL runner rollbacks to gracefully recover when the server has already closed the connection

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e23755f9388331a0b1a780060e6485